### PR TITLE
Expand hash algorithm tests in cryptoHelpers.test.mts

### DIFF
--- a/.changeset/dirty-buttons-lay.md
+++ b/.changeset/dirty-buttons-lay.md
@@ -1,0 +1,5 @@
+---
+"@chainfuse/helpers": patch
+---
+
+Expand hash algorithm tests in cryptoHelpers.test.mts

--- a/.changeset/dirty-buttons-lay.md
+++ b/.changeset/dirty-buttons-lay.md
@@ -1,5 +1,5 @@
 ---
-"@chainfuse/helpers": patch
+'@chainfuse/helpers': patch
 ---
 
 Expand hash algorithm tests in cryptoHelpers.test.mts


### PR DESCRIPTION
This pull request enhances the test coverage for the `CryptoHelpers` module by introducing parameterized tests for multiple hash algorithms. The changes improve the maintainability and accuracy of the tests for both Node.js and browser environments.

### Test Improvements:

* **Parameterized Tests for Hashing**:
  - Added a `hashAlgorithms` array to define test parameters for various hash algorithms (`SHA-1`, `SHA-256`, `SHA-384`, `SHA-512`), including their names, corresponding Node.js algorithm identifiers, and expected hash lengths.
  - Replaced individual test cases with parameterized tests that iterate over the `hashAlgorithms` array, ensuring comprehensive coverage for each algorithm.

* **Validation Enhancements**:
  - Updated tests to compare the actual hash output with the expected hash generated using Node.js's `createHash` function, ensuring correctness and consistency in both Node.js and browser environments.

### Codebase Maintenance:

* **Dependency Addition**:
  - Imported the `createHash` function from `node:crypto` to facilitate hash generation for test validation.